### PR TITLE
Add compatibility with GCC <= 11.2 & Clang 10

### DIFF
--- a/include-gcc/mwaitintrin.h
+++ b/include-gcc/mwaitintrin.h
@@ -24,11 +24,13 @@
 #ifndef _MWAITINTRIN_H_INCLUDED
 #define _MWAITINTRIN_H_INCLUDED
 
+#if ((__GNUC__ >= 12) || (__GNUC__ == 11 && __GNUC_MINOR__ >= 3))
 #ifndef __MWAIT__
 #pragma GCC push_options
 #pragma GCC target("mwait")
 #define __DISABLE_MWAIT__
 #endif /* __MWAIT__ */
+#endif /* GCC >= 11.3 */
 
 extern __inline void
 __attribute__((__gnu_inline__, __always_inline__, __artificial__))

--- a/include-llvm/immintrin.h
+++ b/include-llvm/immintrin.h
@@ -509,9 +509,11 @@ _storebe_i64(void * __P, long long __D) {
 #endif
 #endif
 
+#if (__clang_major__ >= 11)
 #if !(defined(_MSC_VER) || defined(__SCE__)) || __has_feature(modules) ||      \
     defined(__AMXTILE__) || defined(__AMXINT8__) || defined(__AMXBF16__)
 #include <amxintrin.h>
+#endif
 #endif
 
 #if !(defined(_MSC_VER) || defined(__SCE__)) || __has_feature(modules) ||      \
@@ -529,6 +531,7 @@ _storebe_i64(void * __P, long long __D) {
 #include <enqcmdintrin.h>
 #endif
 
+#if (__clang_major__ >= 11)
 #if !(defined(_MSC_VER) || defined(__SCE__)) || __has_feature(modules) ||      \
     defined(__SERIALIZE__)
 #include <serializeintrin.h>
@@ -537,6 +540,7 @@ _storebe_i64(void * __P, long long __D) {
 #if !(defined(_MSC_VER) || defined(__SCE__)) || __has_feature(modules) ||      \
     defined(__TSXLDTRK__)
 #include <tsxldtrkintrin.h>
+#endif
 #endif
 
 #if defined(_MSC_VER) && __has_extension(gnu_asm)


### PR DESCRIPTION
This changeset adds compiler version checks around problematic code not understood by older versions of compilers, enabling support for:
- GCC 11.x older than 11.3 (i.e. 11.1.x, 11.2.x)
- Clang 10.x